### PR TITLE
Load Mapillary CSS and fix viewer instantiation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8" />
 <title>MapiGuesser</title>
 <link href="https://unpkg.com/maplibre-gl@3.0.0/dist/maplibre-gl.css" rel="stylesheet" />
+<link rel="stylesheet" href="https://unpkg.com/@mapillary/js@4.0.0/dist/mapillary.min.css">
 <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -76,7 +76,7 @@ async function loadNewPano() {
   const pano = await fetchRandomPano();
   actualCoords = { lat: pano.lat, lng: pano.lng };
   if (!viewer) {
-    viewer = new Mapillary.Viewer({
+    viewer = new mapillary.Viewer({
       container: 'mly',
       accessToken: MAPILLARY_API_KEY,
       imageId: pano.id

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8" />
 <title>MapiGuesser</title>
 <link href="https://unpkg.com/maplibre-gl@3.0.0/dist/maplibre-gl.css" rel="stylesheet" />
+<link rel="stylesheet" href="https://unpkg.com/@mapillary/js@4.0.0/dist/mapillary.min.css">
 <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>

--- a/js/game.js
+++ b/js/game.js
@@ -76,7 +76,7 @@ async function loadNewPano() {
   const pano = await fetchRandomPano();
   actualCoords = { lat: pano.lat, lng: pano.lng };
   if (!viewer) {
-    viewer = new Mapillary.Viewer({
+    viewer = new mapillary.Viewer({
       container: 'mly',
       accessToken: MAPILLARY_API_KEY,
       imageId: pano.id


### PR DESCRIPTION
## Summary
- ensure Mapillary viewer styles load in main and docs pages
- instantiate Mapillary viewer with correct lowercase name in game scripts

## Testing
- `npm test`
- `curl -i https://graph.mapillary.com/images?...` (HTTP 403, Mapillary API blocked so viewer verification not possible)


------
https://chatgpt.com/codex/tasks/task_e_6892eaae2c28832bb5a07aeffdc3e4f0